### PR TITLE
Fix a potential error when updating submodules locally

### DIFF
--- a/update-submodules.sh
+++ b/update-submodules.sh
@@ -6,6 +6,7 @@ git submodule foreach '
   git checkout $(git rev-parse --abbrev-ref HEAD)
   git reset --hard origin/HEAD
 '
+git branch -d submodule-update-tracking
 git checkout -b submodule-update-tracking
 git add .
 git commit -m "Update all submodules to the latest HEAD"


### PR DESCRIPTION
If the old branch is still present, `git checkout -b` will fail. Doesn't affect CI runs.