### PR TITLE
Add a cleanup script to semi-automatically delete outdated snapshots

### DIFF
--- a/delete-old-snapshots.sh
+++ b/delete-old-snapshots.sh
@@ -3,6 +3,9 @@ set -eu
 test $GH_TOKEN # Mandatory
 echo "Using GitHub token: $GH_TOKEN"
 
+# Local tags may be out of sync (just delete any offenders)
+git fetch --prune --prune-tags origin
+
 # Delete all but the latest snapshot (no point in storing them)
 OUTDATED_RELEASE_TAGS=$(git tag --sort=-creatordate | tail -n +2)
 TAG_COUNT=$(git tag --sort=-creatordate | tail -n +2 | wc -l)

--- a/delete-old-snapshots.sh
+++ b/delete-old-snapshots.sh
@@ -1,0 +1,15 @@
+set -eu
+
+test $GH_TOKEN # Mandatory
+echo "Using GitHub token: $GH_TOKEN"
+
+# Delete all but the latest snapshot (no point in storing them)
+OUTDATED_RELEASE_TAGS=$(git tag --sort=-creatordate | tail -n +2)
+TAG_COUNT=$(git tag --sort=-creatordate | tail -n +2 | wc -l)
+
+echo "Found $TAG_COUNT outdated release tags"
+
+for TAG in $OUTDATED_RELEASE_TAGS; do
+    echo "Deleting tagged release  $TAG"
+    gh release delete "$TAG" --yes --cleanup-tag
+done


### PR DESCRIPTION
They're taking up a lot of space, but I haven't found a setting that would allow deleting them automatically.