### PR TITLE
Add a separate submodule for Horizon's GitLab repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -130,3 +130,6 @@
 [submodule "Servers/horizon"]
 	path = Servers/horizon
 	url = https://github.com/rdw-forks/horizon.git
+[submodule "Servers/ProjectHorizon"]
+	path = Servers/ProjectHorizon
+	url = http://lab.projecthorizon.xyz/horizon/horizon.git


### PR DESCRIPTION
Keeping the fork as well, just in case the author changes his mind again.